### PR TITLE
feat(airflow): add most addons for installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ The default is `airflow:airflow`.
   - `gosu`
   - `tini`
   - `conda`
+- Advertized Airflow add-ons, all `conda-forge` add-ons found here
+  <https://anaconda.org/search?q=airflow> are installed except:
+  - `airflow-with-azure`
+  - `airflow-with-github_enterprise`
+  - `airflow-with-hive`
 - Advertized JARs for Hadoop:
   - Hadoop AWS SDK
   - AWS Java SDK Bundle

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,17 +91,95 @@ RUN set -euo pipefail && \
     CRYPTOGRAPHY_NORM_VERSION="$(printf "%s.%s" "${CRYPTOGRAPHY_VERSION}" "*" | cut -d '.' -f1,2,3)"; \
     PSYCOPG2_NORM_VERSION="$(printf "%s.%s" "${PSYCOPG2_VERSION}" "*" | cut -d '.' -f1,2,3)"; \
     FLASK_BCRYPT_NORM_VERSION="$(printf "%s.%s" "${FLASK_BCRYPT_VERSION}" "*" | cut -d '.' -f1,2,3)"; \
-    conda install -y \
-        "python=${PYTHON_VERSION}" \
-        "airflow=${AIRFLOW_NORM_VERSION}" \
-        "airflow-with-crypto=${AIRFLOW_NORM_VERSION}" \
-        "airflow-with-s3=${AIRFLOW_NORM_VERSION}" \
-        "sqlalchemy=${SQLALCHEMY_NORM_VERSION}" \
-        "boto3=${BOTO3_NORM_VERSION}" \
-        "cryptography=${CRYPTOGRAPHY_NORM_VERSION}" \
-        "psycopg2=${PSYCOPG2_NORM_VERSION}" \
-        "flask-bcrypt=${FLASK_BCRYPT_NORM_VERSION}" \
-        ; \
+    if [[ "${AIRFLOW_NORM_VERSION}" == "1.9.*" ]]; then \
+        conda install -y \
+            "python=${PYTHON_VERSION}" \
+            "airflow=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-async=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-celery=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-cgroups=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-cloudant=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-crypto=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-dask=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-databricks=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-datadog=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-docker=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-emr=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-hdfs=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-jdbc=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-jira=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-ldap=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-mssql=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-password=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-postgres=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-qds=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-rabbitmq=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-redis=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-s3=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-salesforce=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-samba=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-slack=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-ssh=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-statsd=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-vertica=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-webhdfs=${AIRFLOW_NORM_VERSION}" \
+            "sqlalchemy=${SQLALCHEMY_NORM_VERSION}" \
+            "boto3=${BOTO3_NORM_VERSION}" \
+            "cryptography=${CRYPTOGRAPHY_NORM_VERSION}" \
+            "psycopg2=${PSYCOPG2_NORM_VERSION}" \
+            "flask-bcrypt=${FLASK_BCRYPT_NORM_VERSION}" \
+            ; \
+    else \
+        conda install -y \
+            "python=${PYTHON_VERSION}" \
+            "airflow=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-async=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-azure_blob_storage=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-azure_cosmos=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-azure-mgmt-containerinstance=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-cassandra=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-celery=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-cgroups=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-cloudant=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-crypto=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-dask=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-databricks=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-datadog=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-docker=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-druid=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-elasticsearch=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-emr=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-hdfs=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-jdbc=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-jenkins=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-jira=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-kubernetes=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-ldap=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-mongo=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-mssql=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-mysql=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-password=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-postgres=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-qds=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-rabbitmq=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-redis=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-s3=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-salesforce=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-samba=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-sendgrid=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-slack=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-ssh=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-statsd=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-vertica=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-webhdfs=${AIRFLOW_NORM_VERSION}" \
+            "airflow-with-winrm=${AIRFLOW_NORM_VERSION}" \
+            "sqlalchemy=${SQLALCHEMY_NORM_VERSION}" \
+            "boto3=${BOTO3_NORM_VERSION}" \
+            "cryptography=${CRYPTOGRAPHY_NORM_VERSION}" \
+            "psycopg2=${PSYCOPG2_NORM_VERSION}" \
+            "flask-bcrypt=${FLASK_BCRYPT_NORM_VERSION}" \
+            ; \
+    fi; \
     conda clean -a -y; \
     :
 


### PR DESCRIPTION
With the exception of:
- `airflow-with-azure`
- `airflow-with-github_enterprise`
- `airflow-with-hive`

The above are omitted because at the moment, the above add-on packages
are too old.